### PR TITLE
Add api doc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jbuilder'
 
 # gem 'bcrypt', '~> 3.1.7'
 
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data'
 
 gem 'bootsnap', require: false
 
@@ -61,3 +61,5 @@ end
 gem 'will_paginate', '~> 3.3'
 
 gem 'active_model_serializers', '~> 0.10.13'
+
+gem 'rswag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     digest (3.1.0)
     erubi (1.11.0)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -130,6 +131,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.2)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     loofah (2.19.0)
       crass (~> 1.0.2)
@@ -157,6 +160,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.8-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -164,6 +169,7 @@ GEM
     parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.3)
+    pg (1.4.3-x64-mingw-ucrt)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -227,6 +233,19 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.11.1)
+    rswag (2.6.0)
+      rswag-api (= 2.6.0)
+      rswag-specs (= 2.6.0)
+      rswag-ui (= 2.6.0)
+    rswag-api (2.6.0)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.6.0)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.1)
+    rswag-ui (2.6.0)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.36.0)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -273,6 +292,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2022.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.3.0)
     uniform_notifier (1.16.0)
     warden (1.2.9)
@@ -296,6 +317,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
@@ -314,6 +336,7 @@ DEPENDENCIES
   rails (~> 7.0.4)
   rails-controller-testing
   rspec-rails (~> 6.0)
+  rswag
   rubocop (>= 1.0, < 2.0)
   sassc-rails
   selenium-webdriver

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,9 @@ default: &default
 
 development:
   <<: *default
-  database: blog_app_development
+  database: blog_app_two
+  username: moraad
+  password: 23568900
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -57,7 +59,9 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: blog_app_test
+  database: blog_app_two
+  username: moraad
+  password: 23568900
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,6 +85,6 @@ test:
 #
 production:
   <<: *default
-  database: blog_app_production
-  username: blog_app
-  password: <%= ENV["BLOG_APP_DATABASE_PASSWORD"] %>
+  database: blog_app_two
+  username: moraad
+  password: 23568900

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users
 
   root to: 'users#index'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,7 +77,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_13_184742) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.string "role"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -1,0 +1,48 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/comments', type: :request do
+
+  path '/api/v1/users/{user_id}/posts/{post_id}/comments' do
+
+    parameter name: 'user_id', in: :path, type: :integer, description: 'Author Id'
+    parameter name: 'post_id', in: :path, type: :integer, description: 'Post Id'
+
+    get('list comments') do
+      produces 'application/json'
+
+      response(200, '') do
+        schema '$ref' => '#/components/schemas/comments'
+
+        run_test!
+      end
+
+      response(404, 'comments not found') { run_test! }
+    end
+  end
+
+  path '/api/v1/posts/{post_id}/comments' do
+    parameter name: 'post_id', in: :path, type: :integer, description: 'Post Id'
+
+    post('create comment') do
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :comment, in: :body, schema: { '$ref' => '#/components/schemas/comment' }
+      security [{ bearerAuth: [] }]
+
+      response(201, 'created successfully!') do
+        schema '$ref' => '#/components/schemas/comment_failed'
+
+        run_test!
+      end
+
+      response(401, 'unauthorized') { run_test! }
+
+      response(:unprocessable_entity, 'Error') do
+        schema '$ref' => '#/components/schemas/comment_failed'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -1,0 +1,22 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/posts', type: :request do
+
+  path '/api/v1/users/{user_id}/posts' do
+    parameter name: 'user_id', in: :path, type: :integer, description: 'Author Id'
+
+    get('list posts') do
+      consumes 'application/json'
+
+      response(200, '') do
+        schema '$ref' => '#/components/schemas/posts'
+
+        let(:user_id) { 12 }
+
+        run_test!
+      end
+
+      response(404, 'No posts found') { run_test! }
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,84 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/users/{user_id}/posts/{post_id}/comments":
+    parameters:
+    - name: user_id
+      in: path
+      description: Author Id
+      required: true
+      schema:
+        type: integer
+    - name: post_id
+      in: path
+      description: Post Id
+      required: true
+      schema:
+        type: integer
+    get:
+      summary: list comments
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/comments"
+        '404':
+          description: comments not found
+  "/api/v1/posts/{post_id}/comments":
+    parameters:
+    - name: post_id
+      in: path
+      description: Post Id
+      required: true
+      schema:
+        type: integer
+    post:
+      summary: create comment
+      parameters: []
+      security:
+      - bearerAuth: []
+      responses:
+        '201':
+          description: created successfully!
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/comment_failed"
+        '401':
+          description: unauthorized
+        unprocessable_entity:
+          description: Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/comment_failed"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/comment"
+  "/api/v1/users/{user_id}/posts":
+    parameters:
+    - name: user_id
+      in: path
+      description: Author Id
+      required: true
+      schema:
+        type: integer
+    get:
+      summary: list posts
+      responses:
+        '200':
+          description: ''
+        '404':
+          description: No posts found
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com


### PR DESCRIPTION
### Requirements

1. Write the API integration specs using [rswag](https://github.com/rswag/rswag#getting-started) for your existing endpoints.
2. Generate the documentation.